### PR TITLE
Updated hilt and AGP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,14 @@
 buildscript {
     ext {
         compose_version = '1.0.5'
-        hilt_version = '2.37'
+        hilt_version = '2.38.1'
     }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.1.0-alpha02")
+        classpath("com.android.tools.build:gradle:7.1.3")
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
 
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Nov 07 13:35:29 CST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The version of the android gradle plugin used here is not compatible with android studio dolphin, and there's a bug in the version of hilt after upgrading AGP, so this PR upgrades both.

Cool example, thanks for sharing this!